### PR TITLE
Add `extract_subset`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -260,7 +260,25 @@ You can also pass the ``argument`` to the ``Choices`` constructor to create a su
 the choices entries added at the same time (it will call ``add_choices`` with the name and the
 entries)
 
-The list of existing subset names is in the ``subsets`` attributes of the parent ``Choicess`` object.
+The list of existing subset names is in the ``subsets`` attributes of the parent ``Choices``
+object.
+
+If you want a subset of the choices but not save it in the original ``Choices`` object, you can
+use ``extract_subset`` instead of ``add_subset``
+
+.. code-block:: python
+
+    >>> subset = STATES.extract_subset('DRAFT', 'OFFLINE')
+    >>> subset
+    (2, 'Draft')
+    (3, 'Offline')
+
+
+As for a subset created by ``add_subset``, you have a real ``Choices`` object, but not accessible
+from the original ``Choices`` object.
+
+Note that in ``extract_subset``, you pass the strings directly, not in a list/tuple as for the
+second argument of ``add_subset``.
 
 Notes
 -----

--- a/extended_choices/tests.py
+++ b/extended_choices/tests.py
@@ -312,6 +312,56 @@ class ChoicesTestCase(BaseTestCase):
                 name='EXTENDED'
             )
 
+    def test_extracting_subset(self):
+        """Test that we can extract a subset of choices."""
+
+        subset = self.MY_CHOICES.extract_subset('ONE', 'TWO')
+
+        self.assertIsInstance(subset, Choices)
+
+        # Test django expected tuples
+        expected = (
+            (1, 'One for the money'),
+            (2, 'Two for the show'),
+        )
+
+        self.assertEqual(subset, expected)
+        self.assertEqual(subset.choices, expected)
+
+        # Test entries
+        self.assertEqual(len(subset.entries), 2)
+        self.assertIsInstance(subset.entries[0], ChoiceEntry)
+        self.assertEqual(subset.entries[0].constant, 'ONE')
+        self.assertEqual(subset.entries[0].value, 1)
+        self.assertEqual(subset.entries[0].display, 'One for the money')
+
+        self.assertIsInstance(subset.entries[1], ChoiceEntry)
+        self.assertEqual(subset.entries[1].constant, 'TWO')
+        self.assertEqual(subset.entries[1].value, 2)
+        self.assertEqual(subset.entries[1].display, 'Two for the show')
+
+        # Test dicts
+        self.assertEqual(len(subset.constants), 2)
+        self.assertEqual(len(subset.values), 2)
+        self.assertEqual(len(subset.displays), 2)
+
+        self.assertIs(subset.constants['ONE'],
+                      self.MY_CHOICES.constants['ONE'])
+        self.assertIs(subset.constants['TWO'],
+                      self.MY_CHOICES.constants['TWO'])
+        self.assertIs(subset.values[1],
+                      self.MY_CHOICES.constants['ONE'])
+        self.assertIs(subset.values[2],
+                      self.MY_CHOICES.constants['TWO'])
+        self.assertIs(subset.displays['One for the money'],
+                      self.MY_CHOICES.constants['ONE'])
+        self.assertIs(subset.displays['Two for the show'],
+                      self.MY_CHOICES.constants['TWO'])
+
+        # Test ``in``
+        self.assertIn(1, subset)
+        self.assertNotIn(4, subset)
+
     def test_creating_subset(self):
         """Test that we can add subset of choices."""
 


### PR DESCRIPTION
It is used to get a subset without attaching it to the original `Choices` object.
Note that internally, `add_subset` use it before attaching it.