### PR TITLE
Upgrade Django & Python supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,70 @@
-language: python
 sudo: false
+language: python
+matrix:
+  fast_finish: true
+  include:
+    # Python version is just for the look on travis.
+    - python: 2.7
+      env: TOXENV=flake8
 
-cache:
-  directories:
-    - $HOME/.cache/pip
+    - python: 2.7
+      env: TOXENV=py27-django18
 
-python:
- - "2.6"
- - "2.7"
- - "3.3"
- - "3.4"
- - "3.5"
+    - python: 2.7
+      env: TOXENV=py27-django19
 
-env:
- - DJANGO="Django<1.6"
- - DJANGO="Django<1.7"
- - DJANGO="Django<1.8"
- - DJANGO="Django<1.9"
- - DJANGO="Django<1.10"
- - DJANGO="Django<1.11"
+    - python: 2.7
+      env: TOXENV=py27-django110
+
+    - python: 2.7
+      env: TOXENV=py27-django111
+
+    - python: 3.3
+      env: TOXENV=py33-django18
+
+    - python: 3.4
+      env: TOXENV=py34-django18
+
+    - python: 3.4
+      env: TOXENV=py34-django19
+
+    - python: 3.4
+      env: TOXENV=py34-django110
+
+    - python: 3.4
+      env: TOXENV=py34-django111
+
+    - python: 3.4
+      env: TOXENV=py34-djangomaster
+
+    - python: 3.5
+      env: TOXENV=py35-django18
+
+    - python: 3.5
+      env: TOXENV=py35-django19
+
+    - python: 3.5
+      env: TOXENV=py35-django110
+
+    - python: 3.5
+      env: TOXENV=py35-django111
+
+    - python: 3.5
+      env: TOXENV=py35-djangomaster
+
+    - python: 3.6
+      env: TOXENV=py36-django111
+
+    - python: 3.6
+      env: TOXENV=py36-djangomaster
+
+  allow_failures:
+    - env: TOXENV=py34-djangomaster
+    - env: TOXENV=py35-djangomaster
+    - env: TOXENV=py36-djangomaster
 
 install:
- - pip install -q $DJANGO
- - pip install -q -e .
+- pip install tox
 
-cache: pip
-
-script: "python -m extended_choices.tests"
-
-matrix:
-  exclude:
-    - python: "3.5"
-      env: DJANGO="Django<1.6"
-    - python: "3.5"
-      env: DJANGO="Django<1.7"
-    - python: "3.5"
-      env: DJANGO="Django<1.8"
-
-    - python: "3.4"
-      env: DJANGO="Django<1.6"
-    - python: "3.4"
-      env: DJANGO="Django<1.7"
-
-    - python: "3.3"
-      env: DJANGO="Django<1.6"
-    - python: "3.3"
-      env: DJANGO="Django<1.10"
-    - python: "3.3"
-      env: DJANGO="Django<1.11"
-
-    - python: "2.6"
-      env: DJANGO="Django<1.8"
-    - python: "2.6"
-      env: DJANGO="Django<1.9"
-    - python: "2.6"
-      env: DJANGO="Django<1.10"
-    - python: "2.6"
-      env: DJANGO="Django<1.11"
+script:
+- tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+---------------------------------
+* django-extended-choices supports Django 1.8, 1.9, 1.10 and 1.11
+* django-extended-choices Python supports now follow the latests django support matrix
+* Add a tox configuration (tests, pep8 validation and code coverage)
+* Update the travis configuration accordingly
+
 Release *v1.1.1* - ``2016-11-03``
 ---------------------------------
 * make ``OrderedChoices`` available at the package root

--- a/README.rst
+++ b/README.rst
@@ -303,12 +303,21 @@ License
 
 Available under the BSD_ License. See the ``LICENSE`` file included
 
-Python 3?
+Python versions support
 ---------
 
-Of course! We support python ``2.6``, ``2.7``, ``3.3``, ``3.4`` and ``3.5``, for Django version
-``1.5.x`` to ``1.10.x``, respecting the `Django matrix`_ (except for python ``2.5`` and ``3.2``
-which are not supported by ``django-extended-choices``)
+``django-extended-choices`` Python support follow the `Django Python support matrix`_:
+
+
++----------------+-------------------------------------------------+
+| Django version | Python versions                                 |
++----------------+-------------------------------------------------+
+| 1.8            | 2.7, 3.2 (until the end of 2016), 3.3, 3.4, 3.5 |
++----------------+-------------------------------------------------+
+| 1.9, 1.10      | 2.7, 3.4, 3.5                                   |
++----------------+-------------------------------------------------+
+| 1.11           | 2.7, 3.4, 3.5, 3.6                              |
++----------------+-------------------------------------------------+
 
 
 Tests
@@ -369,7 +378,7 @@ Written by Stephane "Twidi" Angel <s.angel@twidi.com> (http://twidi.com), origin
 .. _choices: http://docs.djangoproject.com/en/1.5/ref/models/fields/#choices
 .. _Django: http://www.djangoproject.com/
 .. _Github: https://github.com/twidi/django-extended-choices
-.. _Django matrix: https://docs.djangoproject.com/en/1.8/faq/install/#what-python-version-can-i-use-with-django
+.. _Django Python support matrix: https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-can-i-use-with-django
 .. _TravisCi: https://travis-ci.org/twidi/django-extended-choices/pull_requests
 .. _ReadTheDoc: http://django-extended-choices.readthedocs.org
 .. _BSD: http://opensource.org/licenses/BSD-3-Clause

--- a/extended_choices/__init__.py
+++ b/extended_choices/__init__.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from .choices import Choices, OrderedChoices
 
+__all__ = ['Choices', 'OrderedChoices']
 __author__ = 'Stephane "Twidi" Ange;'
 __contact__ = "s.angel@twidi.com"
 __homepage__ = "https://pypi.python.org/pypi/django-extended-choices"

--- a/extended_choices/choices.py
+++ b/extended_choices/choices.py
@@ -864,7 +864,6 @@ class OrderedChoices(Choices):
         super(OrderedChoices, self).__init__(*choices, **kwargs)
 
 
-
 def create_choice(klass, choices, subsets, kwargs):
     """Create an instance of a ``Choices`` object.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+envlist =
+    py{27,33,34,35}-django{18},
+    py{27,34,35}-django{19,110},
+    py{27,34,35,36}-django{111},
+    py{34,35,36}-djangomaster
+    flake8
+
+[testenv]
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+deps =
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
+    djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=django
+    coverage
+commands =
+    pip install -e .
+    pip freeze
+    coverage run -m --source=extended_choices extended_choices.tests
+    coverage report
+
+[testenv:flake8]
+basepython = python2.7
+deps =
+    flake8
+commands =
+    flake8 extended_choices --ignore E501,E402


### PR DESCRIPTION
django-extended-choices supports Django 1.8, 1.9, 1.10 and 1.11
django-extended-choices Python supports now follow the latests django support matrix
Add a tox configuration (tests, pep8 validation and code coverage)