### PR TITLE
Replace dependency on 'future' package by 'six'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 *egg-info
 # pycharm project directory
 .idea
+.coverage
+.tox

--- a/extended_choices/__init__.py
+++ b/extended_choices/__init__.py
@@ -1,6 +1,7 @@
 """Little helper application to improve django choices (for fields)"""
 from __future__ import unicode_literals
 import pkg_resources
+import six
 from os import path
 from setuptools.config import read_configuration
 
@@ -21,9 +22,5 @@ def _extract_version(package_name):
     return version
 
 
-# '%s' % ... is a hack to ensure EXACT_VERSION is a unicode string in python 2,
-# because pkg_resources.get_distribution(...).version returns a bytes str and
-# that would fail when calling isnumeric() below. It can be safely removed when
-# Python 2 support is removed.
-EXACT_VERSION = '%s' % _extract_version('django_extended_choices')
+EXACT_VERSION = six.text_type(_extract_version('django_extended_choices'))
 VERSION = tuple(int(part) for part in EXACT_VERSION.split('.') if part.isnumeric())

--- a/extended_choices/__init__.py
+++ b/extended_choices/__init__.py
@@ -1,7 +1,6 @@
 """Little helper application to improve django choices (for fields)"""
-
+from __future__ import unicode_literals
 import pkg_resources
-from future.builtins import str
 from os import path
 from setuptools.config import read_configuration
 
@@ -22,5 +21,9 @@ def _extract_version(package_name):
     return version
 
 
-EXACT_VERSION = _extract_version('django_extended_choices')
-VERSION = tuple(int(part) for part in EXACT_VERSION.split('.') if str(part).isnumeric())
+# '%s' % ... is a hack to ensure EXACT_VERSION is a unicode string in python 2,
+# because pkg_resources.get_distribution(...).version returns a bytes str and
+# that would fail when calling isnumeric() below. It can be safely removed when
+# Python 2 support is removed.
+EXACT_VERSION = '%s' % _extract_version('django_extended_choices')
+VERSION = tuple(int(part) for part in EXACT_VERSION.split('.') if part.isnumeric())

--- a/extended_choices/choices.py
+++ b/extended_choices/choices.py
@@ -59,7 +59,7 @@ The documentation format in this file is numpydoc_.
 """
 
 from __future__ import unicode_literals
-from past.builtins import basestring
+import six
 
 from collections import OrderedDict
 try:
@@ -374,7 +374,7 @@ class Choices(list):
 
         # Check for an optional subset name as the first argument (so the first entry of *choices).
         subset_name = None
-        if choices and isinstance(choices[0], basestring) and choices[0] != _NO_SUBSET_NAME_:
+        if choices and isinstance(choices[0], six.string_types) and choices[0] != _NO_SUBSET_NAME_:
             subset_name = choices[0]
             choices = choices[1:]
 
@@ -1031,7 +1031,7 @@ class AutoChoices(AutoDisplayChoices):
                 continue
 
             original_choice = choice
-            if isinstance(choice, basestring):
+            if isinstance(choice, six.string_types):
                 if choice == _NO_SUBSET_NAME_:
                     continue
                 choice = [choice, ]

--- a/extended_choices/fields.py
+++ b/extended_choices/fields.py
@@ -11,7 +11,7 @@ The documentation format in this file is `numpydoc`_.
 
 from __future__ import unicode_literals
 
-from past.builtins import basestring
+import six
 
 from django import forms
 
@@ -42,7 +42,7 @@ class NamedExtendedChoiceFormField(forms.Field):
             return None
 
         # Validate the type.
-        if not isinstance(value, basestring):
+        if not isinstance(value, six.string_types):
             raise forms.ValidationError(
                 "Invalid value type (should be a string).",
                 code='invalid-choice-type',

--- a/extended_choices/helpers.py
+++ b/extended_choices/helpers.py
@@ -11,7 +11,6 @@ The documentation format in this file is numpydoc_.
 
 from __future__ import unicode_literals
 
-from builtins import object  # pylint: disable=redefined-builtin
 try:
     from collections.abc import Mapping
 except ImportError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,8 @@ classifiers =
 [options]
 zip_safe = True
 packages = extended_choices
+install_requires =
+    six
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,6 @@ classifiers =
 [options]
 zip_safe = True
 packages = extended_choices
-install_requires =
-    future
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 
 [options.extras_require]


### PR DESCRIPTION
`future` breaks under tox and python3 for some reason. It turns out that it's barely used in django-extended-choices however, so this PR removes it and replaces it with `six` to improve compatibility.