### PR TITLE
Support Python3.8 and Django3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,9 +89,16 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-djangomaster
 
+    - python: 3.8
+      env: TOXENV=py38-django30
+
+    - python: 3.8
+      env: TOXENV=py38-djangomaster
+
   allow_failures:
     - env: TOXENV=py36-djangomaster
     - env: TOXENV=py37-djangomaster
+    - env: TOXENV=py38-djangomaster
 
 install:
 - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,9 @@ matrix:
       env: TOXENV=py37-django22
 
     - python: 3.7
+      env: TOXENV=py37-django30
+
+    - python: 3.7
       env: TOXENV=py37-djangomaster
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,9 @@ matrix:
       env: TOXENV=py36-django22
 
     - python: 3.6
+      env: TOXENV=py36-django30
+
+    - python: 3.6
       env: TOXENV=py36-djangomaster
 
     - python: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     py{27,34,35,36}-django{111},
     py{34,35,36,37}-django{20},
     py{35,36,37}-django{21,22},
-    py{36,37}-djangomaster,
+    py{36,37,38}-django{30},
+    py{36,37,38}-djangomaster,
     flake8
     doctests
 
@@ -15,6 +16,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0
     djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=django
     coverage
 commands =


### PR DESCRIPTION
Hi,

Thank you for creating this library.
`django-extended-choices` is a very convenient and good library.

Change Summary
* support Python 3.8.0 and Django3.0. and update toxenv and travis-ci config.

Thanks